### PR TITLE
fix options handover (issue with disableToolbar)

### DIFF
--- a/src/jquery.bracket.ts
+++ b/src/jquery.bracket.ts
@@ -2216,7 +2216,7 @@ interface BracketOptions<TTeam, TScore, TMData, TUData> {
     }
 
     const internalOpts = parseOptions<TTeam, TScore, TMData, TUData>(
-      originalOpts,
+      opts,
       ctx,
       extension
     );


### PR DESCRIPTION
since the commit for "Refactor argument validation" there is an issue that disableToolbar is not correctly working because its init in case of undefined is not handed over to the parseOptions function. This pull request helps but I guess it would be anyway better to put all the parsing and validation into the parseOptions function.